### PR TITLE
DAI override update and Jumprate change multiplier calc

### DIFF
--- a/contracts/DAIInterestRateModelV3.sol
+++ b/contracts/DAIInterestRateModelV3.sol
@@ -42,12 +42,16 @@ contract DAIInterestRateModelV3 is JumpRateModelV2 {
     }
 
     /**
-     * @notice Update the gapPerBlock parameter of the interest rate model (only callable by owner, i.e. Timelock)
-     * @param gapPerYear The additional margin per year separating the base borrow rate from the roof.
+     * @notice External function to update the parameters of the interest rate model
+     * @param baseRatePerYear The approximate target base APR, as a mantissa (scaled by 1e18). For DAI, this is calculated from DSR and SF. Input not used.
+     * @param gapPerYear The Additional margin per year separating the base borrow rate from the roof. (scaled by 1e18)
+     * @param jumpMultiplierPerYear The jumpMultiplierPerYear after hitting a specified utilization point
+     * @param kink_ The utilization point at which the jump multiplier is applied
      */
-    function updateGap(uint gapPerYear) public {
+    function updateJumpRateModel(uint baseRatePerYear, uint gapPerYear, uint jumpMultiplierPerYear, uint kink_) external {
         require(msg.sender == owner, "only the owner may call this function.");
-        gapPerBlock = gapPerYear / blocksPerYear;
+        gapPerBlock = gapPerYear.div(blocksPerYear);
+        updateJumpRateModelInternal(0, 0, jumpMultiplierPerYear, kink_);
         poke();
     }
 

--- a/contracts/DAIInterestRateModelV3.sol
+++ b/contracts/DAIInterestRateModelV3.sol
@@ -50,7 +50,7 @@ contract DAIInterestRateModelV3 is JumpRateModelV2 {
      */
     function updateJumpRateModel(uint baseRatePerYear, uint gapPerYear, uint jumpMultiplierPerYear, uint kink_) external {
         require(msg.sender == owner, "only the owner may call this function.");
-        gapPerBlock = gapPerYear.div(blocksPerYear);
+        gapPerBlock = gapPerYear / blocksPerYear;
         updateJumpRateModelInternal(0, 0, jumpMultiplierPerYear, kink_);
         poke();
     }

--- a/contracts/JumpRateModelV2.sol
+++ b/contracts/JumpRateModelV2.sol
@@ -129,7 +129,7 @@ contract JumpRateModelV2 is InterestRateModel {
      */
     function updateJumpRateModelInternal(uint baseRatePerYear, uint multiplierPerYear, uint jumpMultiplierPerYear, uint kink_) internal {
         baseRatePerBlock = baseRatePerYear.div(blocksPerYear);
-        multiplierPerBlock = multiplierPerYear.div(blocksPerYear).mul(1e18).div(kink_);
+        multiplierPerBlock = (multiplierPerYear.mul(1e18)).div(blocksPerYear.mul(kink_));
         jumpMultiplierPerBlock = jumpMultiplierPerYear.div(blocksPerYear);
         kink = kink_;
 

--- a/contracts/JumpRateModelV2.sol
+++ b/contracts/JumpRateModelV2.sol
@@ -64,7 +64,7 @@ contract JumpRateModelV2 is InterestRateModel {
      * @param jumpMultiplierPerYear The multiplierPerBlock after hitting a specified utilization point
      * @param kink_ The utilization point at which the jump multiplier is applied
      */
-    function updateJumpRateModel(uint baseRatePerYear, uint multiplierPerYear, uint jumpMultiplierPerYear, uint kink_) public {
+    function updateJumpRateModel(uint baseRatePerYear, uint multiplierPerYear, uint jumpMultiplierPerYear, uint kink_) external {
         require(msg.sender == owner, "only the owner may call this function.");
 
         updateJumpRateModelInternal(baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_);
@@ -129,7 +129,7 @@ contract JumpRateModelV2 is InterestRateModel {
      */
     function updateJumpRateModelInternal(uint baseRatePerYear, uint multiplierPerYear, uint jumpMultiplierPerYear, uint kink_) internal {
         baseRatePerBlock = baseRatePerYear.div(blocksPerYear);
-        multiplierPerBlock = multiplierPerYear.div(blocksPerYear);
+        multiplierPerBlock = multiplierPerYear.div(blocksPerYear).mul(1e18).div(kink_);
         jumpMultiplierPerBlock = jumpMultiplierPerYear.div(blocksPerYear);
         kink = kink_;
 


### PR DESCRIPTION
I haven't updated any tests for this or tested it, but just so you can see what I was talking about.

I think that the meaning behind multiplierPerBlock should be standardized. I like how in the DAI interest rate model, the kink is taken into account so rate is multiplierPerBlock + baseRate at the kink. Now, with JumpRate model, if kink is at 90%, the interest rate will be 0.9*mutiplierPerBlock + baseRate.

For the DAI model, I override the super updateJumpRateModel and the multiplierPerYear field is now gapPerYear.